### PR TITLE
Fix for bug 49: Navbar demo broken in IE7-8

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -426,7 +426,7 @@ function QTip(target, options, id, attr)
 
 			// Check if new target was actually the tooltip element
 			var relatedTarget = $(event.relatedTarget || event.target),
-				ontoTooltip = relatedTarget.parents(selector)[0] === tooltip[0],
+				ontoTooltip = relatedTarget.closest(selector)[0] === tooltip[0],
 				ontoTarget = relatedTarget[0] === targets.show[0];
 
 			// Clear timers and stop animation queue


### PR DESCRIPTION
This fixes the problem in IE7-8 where when using qtip2 as a drop down menu, the drop down menu disappears once you mouse off the triggering element preventing you from selecting elements in the drop down menu.

You can see this bug in action on the current demo page.
