### PR TITLE
Svg fixes

### DIFF
--- a/src/svg.js
+++ b/src/svg.js
@@ -8,7 +8,7 @@ $.fn.qtip.plugins.svg = function(svg, corner)
 		},
 		box, mtx, root, point, tPoint;
 
-	if (elem.getBBox) {
+	if (elem.getBBox && elem.parentNode) {
 		box = elem.getBBox();
 		mtx = elem.getScreenCTM();
 		root = elem.farthestViewportElement || elem;


### PR DESCRIPTION
Here's a small quick fix for the scenario that the SVG element is removed from the DOM (and is still bound to position.target).

This stems from probably a bigger issue of over-checking the position.
Example.. in my codebase I do this logic

```
  $('#RO_InteractiveMap')
            .qtip('option','content.text',zInfo.text || 'Unknown')
            .qtip('option','content.title.text',zInfo.title)
            .qtip('option','position.target',$(this))
            .qtip('show');
```

Where this is the SVG "g" element.  Now if I delete the last active 'g' from the DOM, the next time this code is run qtip2 queries the SVG position 4 more times via the updates of content.text and content.title.text. (and twice for the show).

So I adjusted the code like this.

```
  $('#RO_InteractiveMap')
            .qtip('option','position.target',false)
            .qtip('option','content.text',zInfo.text || 'Unknown')
            .qtip('option','content.title.text',zInfo.title)
            .qtip('option','position.target',$(this))
            .qtip('show');
```

And now it only queries position twice for every 'show'.  Shouldn't the position only be recalculated when the qtip is shown?!?
