### PR TITLE
Redraw tooltip after ajax has been loaded.

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -76,6 +76,8 @@ function Ajax(api)
 
 				// Set the content
 				api.set('content.text', content);
+				api.redraw();
+				api.reposition();
 
 				after(); // Call common callback
 			}


### PR DESCRIPTION
This solved the issue of ajax content being displayed in a narrow tooltip left after loading placeholder. This might not be the best solution though. The redraw method might be better called inside the api.set('content.text', ...) handler.
