### PR TITLE
Removed 2nd argument from slice.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1446,7 +1446,7 @@ QTIP = $.fn.qtip = function(options, notation, newValue)
 {
 	var command = ('' + options).toLowerCase(), // Parse command
 		returned = NULL,
-		args = command === 'disable' ? [TRUE] : $.makeArray(arguments).slice(1, 10),
+		args = command === 'disable' ? [TRUE] : $.makeArray(arguments).slice(1),
 		event = args[args.length - 1],
 		opts = this[0] ? $.data(this[0], 'qtip') : NULL;
 


### PR DESCRIPTION
Removed the upperbound on the slice command used on arguments in the jQuery function declaration.

I've been looking through your source (nice work) but I can't figure out if there is any reason you're slicing 10 arguments instead of just omitting the second argument (which returns the rest of the entries). Figured I'd change it for you and submit a pull request juuuust in case. :)
