### PR TITLE
Workaround for IE when using jQuery Advanced Browser Check

### DIFF
--- a/src/bgiframe/bgiframe.js
+++ b/src/bgiframe/bgiframe.js
@@ -64,7 +64,7 @@ PLUGINS.bgiframe = function(api)
 		self = api.plugins.bgiframe;
 	
 		// Proceed only if the browser is IE6 and offending elements are present
-		if($('select, object').length < 1 || !(browser.msie && browser.version.charAt(0) === '6')) {
+		if($('select, object').length < 1 || !(browser.msie && browser.version.toString().charAt(0) === '6')) {
 		return FALSE;
 	}
 


### PR DESCRIPTION
I added this plugin to my project to detect mobile browsers: http://plugins.jquery.com/project/advbrowsercheck

Unfortunately, the $.browser.version attribute is overwritten to be an integer and charAt() throws an exception. typecasting this one to a string just before executing prevents this and shouldnt conflict with the implementation.

Cheers
