### PR TITLE
Update: line 1627 - Dynamic tooltips and IE, with a .live mouseenter issue

### DIFF
--- a/dist/jquery.qtip.js
+++ b/dist/jquery.qtip.js
@@ -1622,8 +1622,9 @@ function init(id, opts)
 	}
 
 	// Remove title attribute and store it if present
+	// Added empty title, IE displays default browser title on dynamic tooltips
 	if(config.suppress && (title = $.attr(this, 'title'))) {
-		$(this).removeAttr('title').attr(oldtitle, title);
+		$(this).removeAttr('title').attr(oldtitle, title).attr('title','');
 	}
 
 	// Initialize the tooltip and add API reference


### PR DESCRIPTION
Original: $(this).removeAttr('title').attr(oldtitle, title);
Change: $(this).removeAttr('title').attr(oldtitle, title).attr('title','');

Dynamic/Ajax loaded tooltips in IE show the default browser title attribute and tooltip on initial mouseover. Adding .attr('title','') fixes the issue.
