### PR TITLE
Icons in title bar have an underline

### DIFF
--- a/src/core.css
+++ b/src/core.css
@@ -65,6 +65,7 @@
 		.ui-tooltip-icon .ui-icon{
 			display: block;
 			text-indent: -1000em;
+			text-decoration: none;
 		}
 
 		.ui-tooltip-icon, .ui-tooltip-icon .ui-icon{


### PR DESCRIPTION
I've added `text-decoration:none;` to the `core.css` file around line 68.
