### PR TITLE
fixed null ref error inside setWidget

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -139,8 +139,9 @@ function QTip(target, options, id, attr)
 		var on = options.style.widget;
 
 		tooltip.toggleClass(widget, on).toggleClass(defaultClass, options.style.def && !on);
-		elements.content.toggleClass(widget+'-content', on);
-
+		if (elements.content) {
+			elements.content.toggleClass(widget+'-content', on);
+		}
 		if(elements.titlebar){
 			elements.titlebar.toggleClass(widget+'-header', on);
 		}


### PR DESCRIPTION
Calling $(element).qtip("api").set({"content.title.text": "test"}) produces a null ref error on elements.content inside setWidget. http://jsbin.com/oviqen/11/
