### PR TITLE
Small typo in core.js

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -468,7 +468,7 @@ function QTip(target, options, id, attr)
 
 		// Hide tooltip on document mousedown if unfocus events are enabled
 		if(('' + options.hide.event).indexOf('unfocus') > -1) {
-			posOptions.container.closest('html').bind('mousedown'+namespace+' touchstart'+namesace, function(event) {
+			posOptions.container.closest('html').bind('mousedown'+namespace+' touchstart'+namespace, function(event) {
 				var elem = $(event.target),
 					enabled = self.rendered && !tooltip.hasClass(disabled) && tooltip[0].offsetWidth > 0,
 					isAncestor = elem.parents(selector).filter(tooltip[0]).length > 0;


### PR DESCRIPTION
There is a small typo in `src/core.js`. In line 471 says `namesace` instead of `namespace`. The patch attached will fix this.
