### PR TITLE
fixed issue with modal stealing focus even after it is destroyed

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -275,7 +275,7 @@ function Modal(api)
 				}
 
 				// Undelegate focus handler
-				docBody.undelegate('*', 'focusin'+namespace);
+				docBody.unbind('focusin'+namespace);
 			}
 
 			// Remove bound events


### PR DESCRIPTION
When modal qtip is destroyed (for example when it's trigger element is removed from DOM), it doesn't stop stealing focus. I think that the reason is that the event handler is bound using bind, and destroy tries to unbind it using undelegate.

Simple reproduction:
http://jsbin.com/ixodon/1/edit
1. Click a button
2. Wait for modal to disappear
3. Now it is impossible to focus the input and type anything

And with this fix applied:
http://jsbin.com/urorof/1/edit
