### PR TITLE
cssProps issue in ie and jquery 1.9

### DIFF
--- a/src/tips/tips.js
+++ b/src/tips/tips.js
@@ -34,8 +34,7 @@ function vendorCss(elem, prop) {
 	// If the property has already been mapped...
 	if(cssProps[prop]) { return elem.css(cssProps[prop]); }
 
-	for(i in props) {
-		cur = props[i];
+	for(cur in props) {
 		if((val = elem.css(cur)) !== undefined) {
 			return cssProps[prop] = cur, val;
 		}


### PR DESCRIPTION
I ran into an issue while trying to render Tips in ie7.  After some tracing I narrowed it down to line 38 in tips.js.  In ie7 with jQuery 1.9 cur = props[i] would return a function instead of the property name.  By removing line 38 and changing i to cur in the previous line, cur gets each property name and render tips with out error.
