### PR TITLE
Add dist/ and node_modules/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.diff
 *.patch
 .DS_Store
-dist/images
+dist/
+node_modules/


### PR DESCRIPTION
When building qtip2 those folders are created and show up as untracked in git-status. This is especially annoying when including qtip2 as a git submodule since it shows up as dirty in the parent repository.
