### PR TITLE
Fix intCss() in Tips to take care of float value

### DIFF
--- a/src/tips/tips.js
+++ b/src/tips/tips.js
@@ -43,7 +43,7 @@ function vendorCss(elem, prop) {
 
 // Parse a given elements CSS property into an int
 function intCss(elem, prop) {
-	return parseInt(vendorCss(elem, prop), 10);
+	return Math.ceil(parseFloat(vendorCss(elem, prop)));
 }
 
 


### PR DESCRIPTION
It fixes a bug on border width calcul in Tips when there is a browser zoom.

To reproduce the bug, you have to zoom + the page BEFORE the tooltip is generated.
