### PR TITLE
Replace dynamic size of overlay with a 100% width and height

### DIFF
--- a/src/modal/modal.css
+++ b/src/modal/modal.css
@@ -1,8 +1,8 @@
 /* Modal plugin */
 #qtip-overlay{
 	position: fixed;
-	left: -10000em;
-	top: -10000em;
+	left: 0; top: 0;
+	width: 100%; height: 100%;
 }
 
 	/* Applied to modals with show.modal.blur set to true */

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -79,17 +79,6 @@ OVERLAY = function()
 			})
 			.hide();
 
-			// Update position on window resize or scroll
-			function resize() {
-				var win = $(window);
-				elem.css({
-					height: win.height(),
-					width: win.width()
-				});
-			}
-			$(window).bind('resize'+MODALSELECTOR, resize);
-			resize(); // Fire it initially too
-
 			// Make sure we can't focus anything outside the tooltip
 			$(document.body).bind('focusin'+MODALSELECTOR, stealFocus);
 
@@ -145,10 +134,9 @@ OVERLAY = function()
 			// Toggle backdrop cursor style on show
 			elem.toggleClass('blurs', options.blur);
 
-			// Set position and append to body on show
+			// Append to body on show
 			if(state) {
-				elem.css({ left: 0, top: 0 })
-					.appendTo(document.body);
+				elem.appendTo(document.body);
 			}
 
 			// Prevent modal from conflicting with show.solo, and don't hide backdrop is other modals are visible


### PR DESCRIPTION
I had a bug with overlay : the overlay was not resized on window resize when a modal was open, it seems that the event was unassigned somewhere.

This fix don't fix the bug, but prevent it : we don't need to resize the overlay because we set to him a 100% width / height. Since the overlay is attached to the body with a fixed position, CSS is enough.

Plus, I moved the top / left = 0 assignement from the javascript to the CSS (better for a user who want to customize these values).

Regards
