### PR TITLE
Fix tooltip position calculation for SVG circles

### DIFF
--- a/src/position/polys.js
+++ b/src/position/polys.js
@@ -96,7 +96,7 @@ PLUGINS.polys = {
 	},
 	ellipse: function(cx, cy, rx, ry, corner) {
 		var c = PLUGINS.polys._angles[ corner.abbrev() ],
-			rxc = rx * Math.cos( c * Math.PI ),
+			rxc = (c === 0 ? 0 : rx * Math.cos( c * Math.PI )),
 			rys = ry * Math.sin( c * Math.PI );
 
 		return {

--- a/src/position/svg.js
+++ b/src/position/svg.js
@@ -32,10 +32,20 @@ PLUGINS.svg = function(api, svg, corner, adjustMethod)
 				elem.cy.baseVal.value
 			);
 
+			var root = elem.farthestViewportElement || elem,
+				viewBoxAdjustment = (root.viewBox ?
+					{
+						x: (root.viewBox ? root.width.baseVal.value / root.viewBox.baseVal.width : 1),
+						y: (root.viewBox ? root.height.baseVal.value / root.viewBox.baseVal.height : 1)
+					}
+					:
+					{ x: 1, y: 1 }
+				);
+
 			result = PLUGINS.polys.ellipse(
 				position[0], position[1],
-				(elem.rx || elem.r).baseVal.value, 
-				(elem.ry || elem.r).baseVal.value,
+				(elem.rx || elem.r).baseVal.value * viewBoxAdjustment.x,
+				(elem.ry || elem.r).baseVal.value * viewBoxAdjustment.y,
 				corner
 			);
 		break;


### PR DESCRIPTION
The tooltip position for SVG circles is not correct if the SVG has a viewBox set. The radius is not adjusted to the zoom the viewBox results to.

In the polys the position for "center" is also wrong, it should return the center of the circle but the x coordinate is wrong.

This fixes both.
