### PR TITLE
Added existence checks to support using the destroy method while the tooltip is being created

### DIFF
--- a/src/core/events.js
+++ b/src/core/events.js
@@ -23,7 +23,7 @@ function showMethod(event) {
 }
 
 function hideMethod(event) {
-	if(this.tooltip.hasClass(CLASS_DISABLED)) { return FALSE; }
+	if(this.tooltip.hasClass(CLASS_DISABLED) || this.destroyed) { return FALSE; }
 
 	// Check if new target was actually the tooltip element
 	var relatedTarget = $(event.relatedTarget),
@@ -36,8 +36,8 @@ function hideMethod(event) {
 
 	// Prevent hiding if tooltip is fixed and event target is the tooltip.
 	// Or if mouse positioning is enabled and cursor momentarily overlaps
-	if(this !== relatedTarget[0] && 
-		(this.options.position.target === 'mouse' && ontoTooltip) || 
+	if(this !== relatedTarget[0] &&
+		(this.options.position.target === 'mouse' && ontoTooltip) ||
 		(this.options.hide.fixed && (
 			(/mouse(out|leave|move)/).test(event.type) && (ontoTooltip || ontoTarget))
 		))
@@ -93,7 +93,7 @@ PROTOTYPE._unbind = function(targets, suffix) {
 
 // Apply common event handlers using delegate (avoids excessive .bind calls!)
 var ns = '.'+NAMESPACE;
-function delegate(selector, events, method) {	
+function delegate(selector, events, method) {
 	$(document.body).delegate(selector,
 		(events.split ? events : events.join(ns + ' ')) + ns,
 		function() {
@@ -122,7 +122,7 @@ $(function() {
 		// On mouseleave...
 		else {
 			// Hide when we leave the tooltip and not onto the show target (if a hide event is set)
-			if(options.position.target === 'mouse' && options.hide.event && 
+			if(options.position.target === 'mouse' && options.hide.event &&
 				options.show.target && !target.closest(options.show.target[0]).length) {
 				this.hide(event);
 			}
@@ -228,6 +228,7 @@ PROTOTYPE._assignInitialEvents = function(event) {
 
 	// Filter and bind events
 	this._bindEvents(showEvents, hideEvents, showTarget, hideTarget, hoverIntent, function() {
+		if(!this.timers) { return FALSE; }
 		clearTimeout(this.timers.show);
 	});
 
@@ -336,6 +337,7 @@ PROTOTYPE._assignEvents = function() {
 			if(options.hide.event) {
 				// Track if we're on the target or not
 				this._bind(showTarget, ['mouseenter', 'mouseleave'], function(event) {
+					if(!this.cache) {return FALSE; }
 					this.cache.onTarget = event.type === 'mouseenter';
 				});
 			}


### PR DESCRIPTION
I was getting errors when I called the destroy() method on a qtip's api before the qtip rendered on the page (while it was still under construction). I added a few checks for this.destroyed or existence to avoid these errors.
