### PR TITLE
Fix to refresh the tip when it flips only (without offset change)

### DIFF
--- a/src/tips/tips.js
+++ b/src/tips/tips.js
@@ -521,7 +521,7 @@ $.extend(Tip.prototype, {
 			shiftflip(vertical, Y, X, TOP, BOTTOM);
 
 			// Update and redraw the tip if needed (check cached details of last drawn tip)
-			if(newCorner.string() !== cache.corner.string() && (cache.cornerTop !== adjust.top || cache.cornerLeft !== adjust.left)) {
+			if(newCorner.string() !== cache.corner.string() || cache.cornerTop !== adjust.top || cache.cornerLeft !== adjust.left) {
 				this.update(newCorner, FALSE);
 			}
 		}


### PR DESCRIPTION
This bug happens if you show the qTip, where the Tip plugin is used and it has to do a flip, eg. options are set to:

``` JavaScript
        position: {
            my: 'left center',
            at: 'right center',
            viewport: $(window),
            adjust: {
                method: 'flip shift',
```

Then qTip's Tips plugin has to do a flip, so my right center is at left center.  
- The first time the qTip is shown, the Tip arrow is drawn correctly
- Then you hide it and show it again without a destroy

The Tip arrow remains facing the opposite way, because only corner.string() changes so it does not update().

I'll try and do a small example fiddle or enter a bug if you would like.
