### PR TITLE
Fix qtip-youtube's tooltip color

### DIFF
--- a/src/css3.css
+++ b/src/css3.css
@@ -31,7 +31,7 @@
 	box-shadow: 0 0 3px #333;
 
 	color: white;
-	border-width: 0;
+	border: 0 solid transparent;
 
 	background: #4A4A4A;
 	background-image: -webkit-gradient(linear,left top,left bottom,color-stop(0,#4A4A4A),color-stop(100%,black));


### PR DESCRIPTION
The default yellow tooltip was showing through for qtip-youtube.
![problem](https://f.cloud.github.com/assets/2075783/2505502/1e119fd0-b39a-11e3-8a86-67fffb55c6d5.png)
