### PR TITLE
viewport fix: dictionary was being treated as a scalar

### DIFF
--- a/src/position/viewport.js
+++ b/src/position/viewport.js
@@ -85,7 +85,7 @@ PLUGINS.viewport = function(api, position, posOptions, targetWidth, targetHeight
 			}
 
 			// Make sure we haven't made things worse with the adjustment and reset if so
-			if(position[side1] < viewportScroll && -position[side1] > overflow2) {
+			if(position[side1] < viewportScroll[side1] && -position[side1] > overflow2) {
 				position[side1] = initialPos; newMy = my.clone();
 			}
 		}


### PR DESCRIPTION
This fixes a problem where "flip" adjustment could make the position even worse.

viewportScroll was changed from scalar to dictionary by ffd8e58a5323af0deccb0a9d8ed763b8f7353516.  Actually, maybe it doesn't even need to be a dictionary since only the side1 key is used.