### PR TITLE
shape error

### DIFF
--- a/dist/jquery.qtip.js
+++ b/dist/jquery.qtip.js
@@ -2419,7 +2419,7 @@ $.extend(Tip.prototype, {
 
 				// Set shape specific attributes
 				$this[ $this.prop ? 'prop' : 'attr' ]({
-					coordsize: newSize[0]+border + ' ' + newSize[1]+border,
+					coordsize: (newSize[0]+border) + ' ' + (newSize[1]+border),
 					path: coords,
 					fillcolor: color[0],
 					filled: !!i,

--- a/src/tips/tips.js
+++ b/src/tips/tips.js
@@ -405,7 +405,7 @@ $.extend(Tip.prototype, {
 
 				// Set shape specific attributes
 				$this[ $this.prop ? 'prop' : 'attr' ]({
-					coordsize: newSize[0]+border + ' ' + newSize[1]+border,
+					coordsize: (newSize[0]+border) + ' ' + (newSize[1]+border),
 					path: coords,
 					fillcolor: color[0],
 					filled: !!i,


### PR DESCRIPTION
wrong shape size
using  IE11 document mode IE8

![qtip2-shape-error](https://cloud.githubusercontent.com/assets/1563652/18724107/770e833a-803b-11e6-9936-2b81b478fefd.jpg)

