### PR TITLE
Fixing API issue when calling set position

### DIFF
--- a/src/core/options.js
+++ b/src/core/options.js
@@ -144,7 +144,7 @@ CHECKS = PROTOTYPE.checks = {
 		// Position checks
 		'^position.(my|at)$': function(obj, o, v){
 			if('string' === typeof v) {
-				this.position[o] = obj[o] = new CORNER(v, o === 'at');
+				this.options.position[o] = obj[o] = new CORNER(v, o === 'at');
 			}
 		},
 		'^position.container$': function(obj, o, v){


### PR DESCRIPTION
The issue occurs while using set with the "position.my" and "position.at" parameters. When setting the position via the API, the position object is not accessed properly through the `this.options.position` object but rather through `this.position`, which is null.