### PR TITLE
Add npm/browserify/webpack support without requiring globals etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /npm-debug.log
 node_modules/
 **/*.nfs*
+test/npm-and-browserify-pack.js

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
       "url": "https://github.com/qTip2/qTip2/blob/master/LICENSE-MIT"
     }
   ],
-  "dependencies": {
+  "peerDependencies": {
     "jquery": ">=1.6.0",
     "imagesloaded": ">=3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:stable": "grunt all --stable && npm run build:bower",
     "build:bower": "node generate-bower.json",
     "start": "grunt",
-    "test": "grunt lint",
+    "test": "grunt lint && node test/npm-and-browserify-gen.js",
     "preversion": "npm test",
     "version": "npm run build:stable && npm run version:add",
     "version:add": "git add dist bower.json",
@@ -50,6 +50,7 @@
     "imagesloaded": ">=3.0.0"
   },
   "devDependencies": {
+    "browserify": "^13.1.1",
     "grunt": "~0.4.5",
     "grunt-cli": "~0.1.13",
     "grunt-contrib-clean": "~0.7.0",
@@ -60,6 +61,8 @@
     "grunt-contrib-watch": "~0.6.1",
     "grunt-eslint": "^17.3.1",
     "grunt-replace": "~0.11.0",
+    "imagesloaded": ">=3.0.0",
+    "jquery": ">=1.6.0",
     "load-grunt-config": "~0.19.1"
   }
 }

--- a/src/core/intro.js
+++ b/src/core/intro.js
@@ -4,14 +4,17 @@
 /* Cache window, document, undefined */
 (function( window, document, undefined ) {
 
-// Uses AMD or browser globals to create a jQuery plugin.
+// Uses CommonJS, AMD, or browser globals to create a jQuery plugin.
 (function( factory ) {
 	"use strict";
-	if(typeof define === 'function' && define.amd) {
-		define(['jquery'], factory);
-	}
-	else if(jQuery && !jQuery.fn.qtip) {
+	if(typeof jQuery !== 'undefined' && !jQuery.fn.qtip) {
 		factory(jQuery);
+	}
+	else if(typeof module !== 'undefined' && module.exports) {
+		module.exports = factory;
+	}
+	else if(typeof define === 'function' && define.amd) {
+		define(['jquery'], factory);
 	}
 }
 (function($) {

--- a/test/globals.html
+++ b/test/globals.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+
+<html>
+
+  <head>
+    <title>globals test page</title>
+    <script src="../node_modules/jquery/dist/jquery.js"></script>
+    <script src="../dist/jquery.qtip.js"></script>
+
+    <link rel="stylesheet" href="../dist/jquery.qtip.css" />
+  </head>
+
+  <body>
+    <button id="test-button">Click me for a qtip</button>
+
+    <script>
+      $('#test-button').qtip({
+        content: 'Hello, world!',
+        show: {
+          event: 'click'
+        },
+        hide: {
+          event: 'unfocus'
+        }
+      });
+    </script>
+  </body>
+
+</html>

--- a/test/npm-and-browserify-gen.js
+++ b/test/npm-and-browserify-gen.js
@@ -1,0 +1,9 @@
+var path = require('path');
+var fs = require('fs');
+var browserify = require('browserify');
+var outPath = path.join( __dirname, 'npm-and-browserify-pack.js' );
+var inPath = path.join( __dirname, 'npm-and-browserify-src.js' );
+
+browserify({
+  entries: [ inPath ]
+}).bundle().pipe( fs.createWriteStream( outPath ) );

--- a/test/npm-and-browserify-src.js
+++ b/test/npm-and-browserify-src.js
@@ -1,0 +1,16 @@
+var $ = require('jquery');
+var registerQtip = require('../dist/jquery.qtip.js');
+
+registerQtip( $ );
+
+$(function(){
+  $('#test-button').qtip({
+    content: 'Hello, world!',
+    show: {
+      event: 'click'
+    },
+    hide: {
+      event: 'unfocus'
+    }
+  });
+});

--- a/test/npm-and-browserify.html
+++ b/test/npm-and-browserify.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+
+<html>
+
+  <head>
+    <title>npm + browserify test page</title>
+    <script src="./npm-and-browserify-pack.js"></script>
+
+    <link rel="stylesheet" href="../dist/jquery.qtip.css" />
+  </head>
+
+  <body>
+    <button id="test-button">Click me for a qtip</button>
+  </body>
+
+</html>


### PR DESCRIPTION
This adds support to qTip2 for use with npm+browserify or npm+webpack.  With this change, you can now do this:

```js
let registerQtip = require('qtip2');
let jQuery = require('jquery);

registerQtip( jQuery );

// now i can do jQuery('#foo').qtip(...)
```

This gives the dev control over when registration happens and it removes the need for globals.

Previously, you'd have to do this:

```js
window.$ = window.jQuery = require('jquery');
require('qtip2');
```

This also makes it better when using qTip2 with tools like Cytoscape.js:

```js
let cytoscape = require('cytoscape');
let registerQtip = require('qtip2');
let jquery = require('jquery');
let registerCyQtip = require('cytoscape-qtip');

registerQtip( jquery );
registerCyQtip( cytoscape, jquery );
```

References: 
- http://stackoverflow.com/questions/40660643/how-to-include-cytoscape-js-extension-cytoscape-qtip-into-an-ember-app
- https://github.com/qTip2/qTip2/issues/755 
- https://github.com/qTip2/qTip2/issues/799

If you have any questions or any concerns, please let me know.

Thanks