### PR TITLE
#689 fix position when body tag has relative + overflow set

### DIFF
--- a/src/core/position.js
+++ b/src/core/position.js
@@ -239,7 +239,7 @@ PROTOTYPE.reposition.offset = function(elem, pos, container) {
 			pos.top -= parentOffset.top + (parseFloat($.css(parent, 'marginTop')) || 0);
 
 			// If this is the first parent element with an overflow of "scroll" or "auto", store it
-			if(!scrolled && (overflow = $.css(parent, 'overflow')) !== 'hidden' && overflow !== 'visible') { scrolled = $(parent); }
+			if(!scrolled && (overflow = $.css(parent, 'overflow')) !== 'hidden' && overflow !== 'visible' && $.prop(parent, 'tagName') !== 'BODY') { scrolled = $(parent); }
 		}
 	}
 	while(parent = parent.offsetParent);


### PR DESCRIPTION
I've not uploaded the grunt compiled files, as I wasn't sure whether that was helpful or not.

This fixes the issues I've been seeing with scroll offsets.