### PR TITLE
JQuery 3.x compatibility fix

### DIFF
--- a/src/position/viewport.js
+++ b/src/position/viewport.js
@@ -19,7 +19,7 @@ PLUGINS.viewport = function(api, position, posOptions, targetWidth, targetHeight
 		return adjusted;
 	}
 
-	// Cach container details
+	// Cache container details
 	containerOffset = container.offset() || adjusted;
 	containerStatic = container.css('position') === 'static';
 
@@ -28,7 +28,7 @@ PLUGINS.viewport = function(api, position, posOptions, targetWidth, targetHeight
 	viewportWidth = viewport[0] === window ? viewport.width() : viewport.outerWidth(FALSE);
 	viewportHeight = viewport[0] === window ? viewport.height() : viewport.outerHeight(FALSE);
 	viewportScroll = { left: fixed ? 0 : viewport.scrollLeft(), top: fixed ? 0 : viewport.scrollTop() };
-	viewportOffset = viewport.offset() || adjusted;
+	viewportOffset = (viewport[0] !== window && viewport.offset()) || adjusted;
 
 	// Generic calculation method
 	function calculate(side, otherSide, type, adjustment, side1, side2, lengthName, targetLength, elemLength) {


### PR DESCRIPTION
Added a check for a viewport type to prevent an invalid function call.

JQuery 3.x does not support calling `$(window).offset()` but throws an error. In previous versions of JQuery `undefined` is returned. This change has no effect on compatibility with previous JQuery versions.
