### PR TITLE
Make jquery a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,10 @@
     }
   ],
   "dependencies": {
-    "jquery": ">=1.6.0",
     "imagesloaded": ">=3.0.0"
+  },
+  "peerDependencies": {
+    "jquery": ">=1.6.0"
   },
   "devDependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
Plugins should specify jQuery as a peer dependency rather than a dependency (https://nodejs.org/en/blog/npm/peer-dependencies/).

Yarn is having issues resolving the correct version of jquery to install when it is specified as a dependency (ie. it is installing 2 versions rather than 1).