### PR TITLE
Add style property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "postversion": "git push --follow-tags && npm publish",
     "recompile": "npm run build:all && git commit dist -m \"Recompile distributable files\"; git push"
   },
+  "style": "dist/jquery.qtip.css",
   "repository": {
     "type": "git",
     "url": "git://github.com/qTip2/qTip2.git"


### PR DESCRIPTION
By adding a reference to the main dist CSS, `gulp` tools such as [`sass-module-importer`](https://www.npmjs.com/package/sass-module-importer) can automatically import the stylesheet:

```scss
@import "qtip2";
```

rather than

```scss
@import "node_modules/qtip2/dist/jquery.qtip";
```