### PR TITLE
Added CommonJS support to exported library

### DIFF
--- a/src/core/intro.js
+++ b/src/core/intro.js
@@ -10,6 +10,9 @@
 	if(typeof define === 'function' && define.amd) {
 		define(['jquery'], factory);
 	}
+	else if(typeof module === 'object' && typeof module.exports === 'object') {
+		module.exports = factory(require('jquery'));
+	}
 	else if(jQuery && !jQuery.fn.qtip) {
 		factory(jQuery);
 	}

--- a/src/core/outro.js
+++ b/src/core/outro.js
@@ -1,2 +1,3 @@
+return $.qtip;
 }));
 }( window, document ));


### PR DESCRIPTION
I changed the files used in the build script to include CommonJS support [according to this article by `npm`](https://blog.npmjs.org/post/112712169830/making-your-jquery-plugin-work-better-with-npm).

Useful for including qTip2 with build tools such as `webpack`